### PR TITLE
fix: 충돌 판정 및 피격 효과음 미적용 수정

### DIFF
--- a/Assets/Scripts/Monster/Monster.cs
+++ b/Assets/Scripts/Monster/Monster.cs
@@ -102,7 +102,7 @@ public class Monster : MonoBehaviour
         if (collision.gameObject.tag == "Player")
         {
             Player player = collision.gameObject.GetComponent<Player>();
-            player.curHealth -= damage;
+            player.GetDamage(damage);
         }
     }
 }

--- a/Assets/Scripts/Monster/ThrowObject.cs
+++ b/Assets/Scripts/Monster/ThrowObject.cs
@@ -18,7 +18,7 @@ public class ThrowObject : MonoBehaviour
         {
             Player player = collision.gameObject.GetComponent<Player>();
 
-            player.curHealth -= damage;
+            player.GetDamage(damage);
         }
 
         Destroy(gameObject);

--- a/Assets/Scripts/Monster/ThrowingMonster.cs
+++ b/Assets/Scripts/Monster/ThrowingMonster.cs
@@ -312,7 +312,7 @@ public class ThrowingMonster : MonoBehaviour
         if (collision.gameObject.tag == "Player")
         {
             Player player = collision.gameObject.GetComponent<Player>();
-            player.curHealth -= damage;
+            player.GetDamage(damage);
         }
     }
 }

--- a/Assets/Scripts/Player/Player.cs
+++ b/Assets/Scripts/Player/Player.cs
@@ -149,9 +149,9 @@ public class Player : MonoBehaviour
     void FixedUpdate()
     {
         // Draw BoxCast Gizmo
-        Debug.DrawRay(rigid.position + new Vector2(0f, 0f), new Vector3(0f, -1.2f, 0f), Color.red);
-        Debug.DrawRay(rigid.position + new Vector2(0.45f, 0f), new Vector3(0f, -1.2f, 0f), Color.yellow);
-        Debug.DrawRay(rigid.position + new Vector2(-0.45f, 0f), new Vector3(0f, -1.2f, 0f), Color.yellow);
+        Debug.DrawRay(rigid.position + new Vector2(0f, 0f), new Vector3(0f, -1.2f * transform.localScale.x, 0f), Color.red);
+        Debug.DrawRay(rigid.position + new Vector2(0.45f * transform.localScale.x, 0f), new Vector3(0f, -1.2f * transform.localScale.x, 0f), Color.yellow);
+        Debug.DrawRay(rigid.position + new Vector2(-0.45f * transform.localScale.x, 0f), new Vector3(0f, -1.2f * transform.localScale.x, 0f), Color.yellow);
 
         DressState();
 
@@ -180,10 +180,10 @@ public class Player : MonoBehaviour
         }
 
         // Landing Platform using BoxCast
-        if (rigid.velocity.y < -1)
+        if (rigid.velocity.y < -0.5f)
         {
             // set box size
-            boxSize = new Vector3(0.9f, 0.6f, 1f);
+            boxSize = new Vector3(0.9f, 0.6f, 1f) * transform.localScale.x;
 
             // BoxCast
             RaycastHit2D boxHit = Physics2D.BoxCast(rigid.position, boxSize, 0f,


### PR DESCRIPTION
Player.cs
BoxCast의 크기를 player의 크기에 비례하도록 수정하여, player가 물병을 획득하여 작아졌을 때의 BoxCast판정을 일치시킴

Monster.cs, ThrowingMonster.cs, ThrowObject.cs
player와 충돌했을 때 피격 효과음이 있는 GetDamage함수를 참조하도록 수정