### PR TITLE
fix: 플레이어 발판 판정, 전등 데미지 판정 수정

### DIFF
--- a/Assets/Prefabs/All/Platform/고정발판/고정발판 200.prefab
+++ b/Assets/Prefabs/All/Platform/고정발판/고정발판 200.prefab
@@ -99,7 +99,7 @@ BoxCollider2D:
   m_IsTrigger: 0
   m_UsedByEffector: 1
   m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0}
+  m_Offset: {x: 0, y: 0.2}
   m_SpriteTilingProperty:
     border: {x: 0, y: 0, z: 0, w: 0}
     pivot: {x: 0.5, y: 0.5}
@@ -110,7 +110,7 @@ BoxCollider2D:
     adaptiveTiling: 0
   m_AutoTiling: 0
   serializedVersion: 2
-  m_Size: {x: 2, y: 0.5}
+  m_Size: {x: 2, y: 0.1}
   m_EdgeRadius: 0
 --- !u!251 &6834888590435689272
 PlatformEffector2D:

--- a/Assets/Prefabs/All/Platform/노랑발판/노랑발판 200.prefab
+++ b/Assets/Prefabs/All/Platform/노랑발판/노랑발판 200.prefab
@@ -11,6 +11,7 @@ GameObject:
   - component: {fileID: 8811467536288805448}
   - component: {fileID: 8811467536288805449}
   - component: {fileID: 8130031628023863385}
+  - component: {fileID: 1167795701787723125}
   - component: {fileID: -4241803240889523820}
   m_Layer: 6
   m_Name: "\uB178\uB791\uBC1C\uD310 200"
@@ -97,9 +98,9 @@ BoxCollider2D:
   m_Density: 1
   m_Material: {fileID: 0}
   m_IsTrigger: 0
-  m_UsedByEffector: 0
+  m_UsedByEffector: 1
   m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0}
+  m_Offset: {x: 0, y: 0.2}
   m_SpriteTilingProperty:
     border: {x: 0, y: 0, z: 0, w: 0}
     pivot: {x: 0.5, y: 0.5}
@@ -110,8 +111,27 @@ BoxCollider2D:
     adaptiveTiling: 0
   m_AutoTiling: 0
   serializedVersion: 2
-  m_Size: {x: 2.01, y: 0.51}
+  m_Size: {x: 2, y: 0.1}
   m_EdgeRadius: 0
+--- !u!251 &1167795701787723125
+PlatformEffector2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8811467536288805450}
+  m_Enabled: 1
+  m_UseColliderMask: 1
+  m_ColliderMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RotationalOffset: 0
+  m_UseOneWay: 1
+  m_UseOneWayGrouping: 0
+  m_SurfaceArc: 160
+  m_UseSideFriction: 0
+  m_UseSideBounce: 0
+  m_SideArc: 1
 --- !u!114 &-4241803240889523820
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/All/Platform/보라발판/발판(보라).prefab
+++ b/Assets/Prefabs/All/Platform/보라발판/발판(보라).prefab
@@ -100,7 +100,7 @@ BoxCollider2D:
   m_IsTrigger: 0
   m_UsedByEffector: 1
   m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0}
+  m_Offset: {x: 0, y: 0.2}
   m_SpriteTilingProperty:
     border: {x: 0, y: 0, z: 0, w: 0}
     pivot: {x: 0.5, y: 0.5}
@@ -111,7 +111,7 @@ BoxCollider2D:
     adaptiveTiling: 0
   m_AutoTiling: 0
   serializedVersion: 2
-  m_Size: {x: 2, y: 0.5}
+  m_Size: {x: 2, y: 0.1}
   m_EdgeRadius: 0
 --- !u!251 &7563801762209052445
 PlatformEffector2D:

--- a/Assets/Prefabs/All/Platform/주황발판/발판(주황).prefab
+++ b/Assets/Prefabs/All/Platform/주황발판/발판(주황).prefab
@@ -100,7 +100,7 @@ BoxCollider2D:
   m_IsTrigger: 0
   m_UsedByEffector: 1
   m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0}
+  m_Offset: {x: 0, y: 0.2}
   m_SpriteTilingProperty:
     border: {x: 0, y: 0, z: 0, w: 0}
     pivot: {x: 0.5, y: 0.5}
@@ -111,7 +111,7 @@ BoxCollider2D:
     adaptiveTiling: 0
   m_AutoTiling: 0
   serializedVersion: 2
-  m_Size: {x: 2, y: 0.5}
+  m_Size: {x: 2, y: 0.1}
   m_EdgeRadius: 0
 --- !u!251 &6584299768675960064
 PlatformEffector2D:

--- a/Assets/Scripts/Block&Trap&Item/LightTrap.cs
+++ b/Assets/Scripts/Block&Trap&Item/LightTrap.cs
@@ -44,23 +44,21 @@ public class LightTrap : MonoBehaviour
         light2d.intensity = 1f;
         yield return new WaitForSeconds(0.1f);
 
+        for (int i = 10; i >= 0; i--)
+        {
+            light2d.intensity = i / 10f;
+            yield return new WaitForSeconds(0.001f);
+        }
+
         boxCollider.enabled = false;
-
-        for (int i = 20; i >= 0; i--)
-        {
-            light2d.intensity = i / 20f;
-            yield return new WaitForSeconds(0.001f);
-        }
-
         yield return new WaitForSeconds(interval);
+        boxCollider.enabled = true;
 
-        for (int i = 0; i <= 20; i++)
+        for (int i = 0; i <= 10; i++)
         {
-            light2d.intensity = i / 20f;
+            light2d.intensity = i / 10f;
             yield return new WaitForSeconds(0.001f);
         }
-
-        boxCollider.enabled = true;
 
         RandomCall();
     }
@@ -69,23 +67,21 @@ public class LightTrap : MonoBehaviour
     {
         yield return new WaitForSeconds(interval);
 
+        for (int i = 10; i >= 0; i--)
+        {
+            light2d.intensity = i / 10f;
+            yield return new WaitForSeconds(0.001f);
+        }
+
         boxCollider.enabled = false;
-
-        for (int i = 20; i >= 0; i--)
-        {
-            light2d.intensity = i / 20f;
-            yield return new WaitForSeconds(0.001f);
-        }
-
         yield return new WaitForSeconds(interval);
+        boxCollider.enabled = true;
 
-        for (int i = 0; i <= 20; i++)
+        for (int i = 0; i <= 10; i++)
         {
-            light2d.intensity = i / 20f;
+            light2d.intensity = i / 10f;
             yield return new WaitForSeconds(0.001f);
         }
-
-        boxCollider.enabled = true;
 
         RandomCall();
     }
@@ -103,28 +99,26 @@ public class LightTrap : MonoBehaviour
         light2d.intensity = 1f;
         yield return new WaitForSeconds(0.05f);
 
-        boxCollider.enabled = false;
-
-        for (int i = 20; i >= 0; i--)
+        for (int i = 10; i >= 0; i--)
         {
-            light2d.intensity = i / 20f;
+            light2d.intensity = i / 10f;
             yield return new WaitForSeconds(0.001f);
         }
 
+        boxCollider.enabled = false;
         yield return new WaitForSeconds(interval);
+        boxCollider.enabled = true;
 
         light2d.intensity = 1f;
         yield return new WaitForSeconds(0.05f);
         light2d.intensity = 0f;
         yield return new WaitForSeconds(0.05f);
 
-        for (int i = 0; i <= 20; i++)
+        for (int i = 0; i <= 10; i++)
         {
-            light2d.intensity = i / 20f;
+            light2d.intensity = i / 10f;
             yield return new WaitForSeconds(0.001f);
         }
-
-        boxCollider.enabled = true;
 
         RandomCall();
     }

--- a/Assets/Scripts/Player/Player.cs
+++ b/Assets/Scripts/Player/Player.cs
@@ -139,16 +139,16 @@ public class Player : MonoBehaviour
         }
 
         // Draw BoxCast Gizmo
-        Debug.DrawRay(rigid.position, new Vector2(0, -0.1f), Color.yellow, 1f);
-        Debug.DrawRay(rigid.position - new Vector2(0.4f, 0), new Vector2(0, -0.1f), Color.red, 1f);
-        Debug.DrawRay(rigid.position - new Vector2(-0.4f, 0), new Vector2(0, -0.1f), Color.red, 1f);
+        Debug.DrawRay(rigid.position, new Vector2(0, -0.2f), Color.yellow, 1f);
+        Debug.DrawRay(rigid.position - new Vector2(0.4f, 0), new Vector2(0, -0.2f), Color.red, 1f);
+        Debug.DrawRay(rigid.position - new Vector2(-0.4f, 0), new Vector2(0, -0.2f), Color.red, 1f);
 
         // Landing Platform using BoxCast
         if (rigid.velocity.y < -0.1f)
         {
             // BoxCast
             boxSize = new Vector3(0.8f, 0.2f, 1f) * transform.localScale.x;
-            RaycastHit2D boxHit = Physics2D.BoxCast(rigid.position, boxSize, 0, Vector2.down, 0, LayerMask.GetMask("Platform"));
+            RaycastHit2D boxHit = Physics2D.BoxCast(rigid.position, boxSize, 0, Vector2.down, 0.1f, LayerMask.GetMask("Platform"));
 
             if (boxHit.collider != null)
             {


### PR DESCRIPTION
고정발판 200.prefab, 노랑발판 200.prefab, 발판(보라).prefab, 발판(주황).prefab 
-콜라이더 크기 및 위치 수정(y offset 0->0.2, y size 0.5->0.1) 
-노랑발판 200에 Platform Effecter가 없는 것을 확인하여 적용

LightTrap.cs
-전등이 반투명(intensity != 0)일 때도 데미지가 적용되도록 콜라이더를 활성화

Player.cs
-BoxCast 수정 (Vector2.down 0.1f)
-Gizmo 수정