### PR TITLE
fix: 탈출구 효과음 전환, 선택 씬 메뉴UI 수정

### DIFF
--- a/Assets/Prefabs/Stage3/Map Object/비상구문1.prefab
+++ b/Assets/Prefabs/Stage3/Map Object/비상구문1.prefab
@@ -223,7 +223,7 @@ AudioSource:
   OutputAudioMixerGroup: {fileID: 0}
   m_audioClip: {fileID: 8300000, guid: caa21775004371d41bdd938ffe64e9d8, type: 3}
   m_PlayOnAwake: 0
-  m_Volume: 1
+  m_Volume: 0.5
   m_Pitch: 1
   Loop: 0
   Mute: 0

--- a/Assets/Scenes/UI.unity
+++ b/Assets/Scenes/UI.unity
@@ -1931,9 +1931,10 @@ RectTransform:
   - {fileID: 1924597149}
   - {fileID: 441684056}
   - {fileID: 864284860}
-  - {fileID: 1474104439638688888}
-  - {fileID: 1455401262}
   - {fileID: 1087373908}
+  - {fileID: 1474104439638688888}
+  - {fileID: 2079625945}
+  - {fileID: 1455401262}
   m_Father: {fileID: 0}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -1989,7 +1990,7 @@ MonoBehaviour:
   stageImage: {fileID: 1523644512}
   allStars: {fileID: 864284859}
   transition: {fileID: 1455401261}
-  menuUI: {fileID: 1474104438825427912}
+  menuUI: {fileID: 2079625942}
   audioSource: {fileID: 219889295}
   allItemPage: {fileID: 1087373907}
   itemPage1: {fileID: 2036270641}
@@ -3771,7 +3772,7 @@ RectTransform:
   - {fileID: 585459778}
   - {fileID: 767779681}
   m_Father: {fileID: 503641511}
-  m_RootOrder: 12
+  m_RootOrder: 10
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -4908,7 +4909,7 @@ RectTransform:
   m_Children:
   - {fileID: 1241899246}
   m_Father: {fileID: 503641511}
-  m_RootOrder: 11
+  m_RootOrder: 13
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0}
   m_AnchorMax: {x: 0.5, y: 1}
@@ -7744,6 +7745,83 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &2079625942
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2079625945}
+  - component: {fileID: 2079625944}
+  - component: {fileID: 2079625943}
+  m_Layer: 5
+  m_Name: Menu
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!114 &2079625943
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2079625942}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0, b: 0, a: 0.392}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &2079625944
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2079625942}
+  m_CullTransparentMesh: 1
+--- !u!224 &2079625945
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2079625942}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1474104438825427915}
+  m_Father: {fileID: 503641511}
+  m_RootOrder: 12
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &2099308414
 GameObject:
   m_ObjectHideFlags: 0
@@ -8141,7 +8219,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!114 &1474104438825427914
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -8181,17 +8259,17 @@ RectTransform:
   m_GameObject: {fileID: 1474104438825427912}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalScale: {x: 1.4999999, y: 1.4999999, z: 0.49999997}
   m_ConstrainProportionsScale: 1
   m_Children:
   - {fileID: 1474104438244015335}
   - {fileID: 1474104439122095955}
-  m_Father: {fileID: 1474104439638688888}
+  m_Father: {fileID: 2079625945}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -909.2333, y: -489.99994}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 500, y: 350}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &1474104439122095916
@@ -8347,10 +8425,9 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 3, y: 3, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 1474104438825427915}
+  m_Children: []
   m_Father: {fileID: 503641511}
-  m_RootOrder: 10
+  m_RootOrder: 11
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 1}
   m_AnchorMax: {x: 1, y: 1}

--- a/Assets/Scripts/Block&Trap&Item/ElevatorHandler.cs
+++ b/Assets/Scripts/Block&Trap&Item/ElevatorHandler.cs
@@ -80,9 +80,12 @@ public class ElevatorHandler : MonoBehaviour
             yield return new WaitForSeconds(0.01f);
         }
 
-        while (audioSource.isPlaying)
+        yield return new WaitForSeconds(1f);
+
+        while (audioSource.volume > 0)
         {
-            yield return new WaitForSeconds(0.1f);
+            audioSource.volume -= 0.003f;
+            yield return new WaitForSeconds(0.01f);
         }
 
         ChangeScene();


### PR DESCRIPTION
비상구문1.prefab
-AudioSource 'Magic Spell - Sleeping spell 1' volume을 1->0.5로 수정

ElevatorHandler.cs
-기존에는 효과음이 종료될 때 씬을 전환시켰으나, 효과음 자체에 무음 구간이 길어 전환이 늦게 일어남
-따라서 임의로 효과음 음향이 페이드 아웃 되도록 수정하여 종료 시 씬을 전환하도록 수정

UI (선택 씬)
-MenuUI의 Transform이 해상도 고정에 따라 조정되어있지 않아 수정
-MenuUI 활성화 시 뒷배경에 어두운 화면 추가
-에셋 설명 페이지가 MenuUI보다 앞에 나오는 것을 확인하여 hierarchy 수정